### PR TITLE
Add Travis CI support for OpenVDB AX 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,88 @@
+# Copyright (c) 2015-2018 DNEG Visual Effects
+#
+# All rights reserved. This software is distributed under the
+# Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+#
+# Redistributions of source code must retain the above copyright
+# and license notice and the following restrictions and disclaimer.
+#
+# *     Neither the name of DNEG Visual Effects nor the names
+# of its contributors may be used to endorse or promote products derived
+# from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+# LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+#
+#
+# Travis yaml script to configure continous integration
+#
+# Author: Matt Warner
+
+os: linux
+
+sudo: required
+dist: trusty
+
+language: cpp
+
+compiler: gcc
+
+addons:
+  apt:
+    sources:
+    # Required for LLVM 5.0.
+    - llvm-toolchain-trusty-5.0
+    packages:
+    - cmake
+    - doxygen
+    - libboost-iostreams1.55-dev
+    - libboost-random1.55-dev
+    - libboost-system1.55-dev
+    - libboost-thread1.55-dev
+    - libcppunit-dev
+    - libghc-zlib-dev
+    - libilmbase-dev
+    - libllvm5.0
+    - libopenexr-dev
+    - libtbb-dev
+    - llvm-5.0
+    - llvm-5.0-dev
+    # Required for vdb_view. TODO: Improve OpenVDB CMake to allow
+    # building of OpenVDB core library without vdb_view.
+    - libglfw-dev
+    - libxcursor-dev
+    - libxi-dev
+    - libxinerama-dev
+    - libxrandr-dev
+
+
+before_install:
+    # TODO: Investigate why OpenVDB's CMake excludes system paths
+    # as this wouldn't be required otherwise
+    - sudo ln -s /usr/lib/x86_64-linux-gnu/libHalf.a /usr/lib/libHalf.a
+    - sudo ln -s /usr/lib/x86_64-linux-gnu/libHalf.so /usr/lib/libHalf.so
+    - sudo ln -s /usr/lib/x86_64-linux-gnu/libIex.a /usr/lib/libIex.a
+    - sudo ln -s /usr/lib/x86_64-linux-gnu/libIex.so /usr/lib/libIex.so
+    - sudo ln -s /usr/lib/x86_64-linux-gnu/libIlmImf.a /usr/lib/libIlmImf.a
+    - sudo ln -s /usr/lib/x86_64-linux-gnu/libIlmImf.so /usr/lib/libIlmImf.so
+    - sudo ln -s /usr/lib/x86_64-linux-gnu/libIlmThread.a /usr/lib/libIlmThread.a
+    - sudo ln -s /usr/lib/x86_64-linux-gnu/libIlmThread.so /usr/lib/libIlmThread.so
+    - sudo ln -s /usr/lib/x86_64-linux-gnu/libImath.a /usr/lib/libImath.a
+    - sudo ln -s /usr/lib/x86_64-linux-gnu/libImath.so /usr/lib/libImath.so
+
+install:
+    - travis/install-blosc.sh
+    - travis/install-openvdb.sh
+
+script: travis/install.sh

--- a/BuildingWithCMake.md
+++ b/BuildingWithCMake.md
@@ -24,7 +24,7 @@ Once these are set, make a temporary directory and from there invoke CMake i.e.
 ```
 mkdir build
 cd build
-cmake -D CMAKE_CXX_FLAGS="-std=c++11 -fext-numeric-literals" \
+cmake \
     -D OPENVDB_ABI_VERSION_NUMBER=4 \
     -D MINIMUM_BOOST_VERSION=1.55 \
     -D ILMBASE_NAMESPACE_VERSIONING=OFF \

--- a/openvdb_ax/cmd/openvdb_ax/main.cc
+++ b/openvdb_ax/cmd/openvdb_ax/main.cc
@@ -38,7 +38,6 @@
 #include <openvdb/openvdb.h>
 #include <openvdb/util/logging.h>
 #include <openvdb/points/PointDelete.h>
-#include <openvdb/pointsdev/PointSort.h>
 
 #ifdef DWA_OPENVDB
 #include <usagetrack.h>

--- a/travis/install-blosc.sh
+++ b/travis/install-blosc.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015-2018 DNEG Visual Effects
+#
+# All rights reserved. This software is distributed under the
+# Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+#
+# Redistributions of source code must retain the above copyright
+# and license notice and the following restrictions and disclaimer.
+#
+# *     Neither the name of DNEG Visual Effects nor the names
+# of its contributors may be used to endorse or promote products derived
+# from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+# LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+#
+# Builds Blosc
+#
+# Author: Matt Warner
+
+echo "Building and installing blosc..."
+
+git clone https://github.com/Blosc/c-blosc.git
+mkdir c-blosc/build
+cd c-blosc/build
+
+cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+make -j 2
+
+sudo make install -j2

--- a/travis/install-openvdb.sh
+++ b/travis/install-openvdb.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015-2018 DNEG Visual Effects
+#
+# All rights reserved. This software is distributed under the
+# Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+#
+# Redistributions of source code must retain the above copyright
+# and license notice and the following restrictions and disclaimer.
+#
+# *     Neither the name of DNEG Visual Effects nor the names
+# of its contributors may be used to endorse or promote products derived
+# from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+# LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+#
+# Builds OpenVDB
+#
+# Author: Matt Warner
+
+echo "Building and installing openvdb..."
+
+export BLOSC_ROOT=/usr
+export BOOST_ROOT=/usr
+export GLFW_ROOT=/usr
+export ILMBASE_ROOT=/usr
+export OPENEXR_ROOT=/usr
+export TBB_ROOT=/usr
+
+git clone https://github.com/dreamworksanimation/openvdb.git openvdb
+mkdir openvdb/build
+cd openvdb/build
+
+cmake \
+    -D CMAKE_CXX_COMPILER=g++ \
+    -D CMAKE_C_COMPILER=gcc \
+    -D OPENVDB_ABI_VERSION_NUMBER=4 \
+    -D MINIMUM_BOOST_VERSION=1.55 \
+    -D ILMBASE_NAMESPACE_VERSIONING=OFF \
+    -D OPENEXR_NAMESPACE_VERSIONING=OFF \
+    -D USE_GLFW3=OFF \
+    -D OPENVDB_BUILD_UNITTESTS=OFF \
+    -D OPENVDB_BUILD_PYTHON_MODULE=OFF \
+    -D CMAKE_INSTALL_PREFIX=/usr \
+    ../
+
+sudo make -j2
+
+sudo make install -j2

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,0 +1,77 @@
+#!/bin/bash -e
+#
+# Copyright (c) 2015-2018 DNEG Visual Effects
+#
+# All rights reserved. This software is distributed under the
+# Mozilla Public License 2.0 ( http://www.mozilla.org/MPL/2.0/ )
+#
+# Redistributions of source code must retain the above copyright
+# and license notice and the following restrictions and disclaimer.
+#
+# *     Neither the name of DNEG Visual Effects nor the names
+# of its contributors may be used to endorse or promote products derived
+# from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDERS' AND CONTRIBUTORS' AGGREGATE
+# LIABILITY FOR ALL CLAIMS REGARDLESS OF THEIR BASIS EXCEED US$250.00.
+#
+# Builds OpenVDB AX
+#
+# Author: Matt Warner
+
+echo "Building openvdb_ax..."
+
+export ILMBASE_ROOT=/usr
+export OPENEXR_ROOT=/usr
+export BOOST_ROOT=/usr
+export TBB_ROOT=/usr
+export BLOSC_ROOT=/usr
+export LLVM_ROOT=/usr
+export CPPUNIT_ROOT=/usr
+export OPENVDB_ROOT=/usr
+
+CURRENT_LOCATION=$PWD
+
+mkdir build
+cd build
+
+# Temporarily change the /usr/bin/llvm-config symlink so CMake chooses
+# the correct version of LLVM.
+ORIGINAL_LLVM_CONFIG=`readlink /usr/bin/llvm-config`
+sudo ln -sfn /usr/bin/llvm-config-5.0 /usr/bin/llvm-config
+
+cmake \
+	-D OPENVDB_ABI_VERSION_NUMBER=4 \
+    -D MINIMUM_BOOST_VERSION=1.55 \
+    -D OPENVDB_AX_BUILD_DOCS=ON \
+    -D OPENVDB_AX_BUILD_UNITTESTS=ON \
+    -D ILMBASE_NAMESPACE_VERSIONING=OFF \
+    ../
+
+make -j2
+
+echo "Installing openvdb_ax..."
+
+sudo make install -j2 &>/dev/null
+
+# Tests require running from the same root as the test snippets.
+cd openvdb_ax
+
+# Don't use ctest as we don't get much info even with verbose flags.
+./vdb_ax_test -v
+
+# Reset the symlink for /usr/bin/llvm-config to original setting.
+sudo ln -sfn $ORIGINAL_LLVM_CONFIG /usr/bin/llvm-config
+
+cd $CURRENT_LOCATION

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -41,8 +41,6 @@ export LLVM_ROOT=/usr
 export CPPUNIT_ROOT=/usr
 export OPENVDB_ROOT=/usr
 
-CURRENT_LOCATION=$PWD
-
 mkdir build
 cd build
 
@@ -73,5 +71,3 @@ cd openvdb_ax
 
 # Reset the symlink for /usr/bin/llvm-config to original setting.
 sudo ln -sfn $ORIGINAL_LLVM_CONFIG /usr/bin/llvm-config
-
-cd $CURRENT_LOCATION

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -50,7 +50,7 @@ ORIGINAL_LLVM_CONFIG=`readlink /usr/bin/llvm-config`
 sudo ln -sfn /usr/bin/llvm-config-5.0 /usr/bin/llvm-config
 
 cmake \
-	-D OPENVDB_ABI_VERSION_NUMBER=4 \
+    -D OPENVDB_ABI_VERSION_NUMBER=4 \
     -D MINIMUM_BOOST_VERSION=1.55 \
     -D OPENVDB_AX_BUILD_DOCS=ON \
     -D OPENVDB_AX_BUILD_UNITTESTS=ON \


### PR DESCRIPTION
This adds a .travis.yml file and some scripts in the new travis/ directory. The build has been set up to utilise the CMake build mechanisms inside openvdb_ax and run the tests for openvdb_ax. This explicitly does not build the OpenVDB AX SOP and this will be a future extension of this work.

The build requires downloading Blosc and OpenVDB and compiling them from source as dependencies for OpenVDB AX. OpenVDB is built as minimally as possible, however due to limitations in it's CMake set up it requires Travis to pull in some additional dependencies unfortunately. There is the additional limitation in the OpenVDB CMake setup which forces us to symlink some of the libraries installed by apt-get which are not being picked up because system paths are being excluded I believe.

There is also a removal of a spurious header include from the command line openvdb_ax main.cc.

Due to the distribution of trusty that is used, there is a small bit of symlink forcing in order for our CMake set up to pick up the correct version of LLVM in travis/install.sh.
