### PR TITLE
Version 0.0.4 - December 12, 2018

### DIFF
--- a/openvdb_ax/CHANGES.md
+++ b/openvdb_ax/CHANGES.md
@@ -1,9 +1,12 @@
 OpenVDB AX Version History
 ==========================
 
-Version 0.0.4 - In Development
+Version 0.0.4 - December 12, 2018
 
     Bug fixes:
+    - Fixed a memory leak in Point and Volume Executable objects.
+    - Fixed an issue with fit() which could use an incorrect precision for
+      floating point arguments.
     - Compilation fixes for the Houdini AX SOP for Houdini 15.5 and earlier.
 
     Improvements:

--- a/openvdb_ax/compiler/PointExecutable.cc
+++ b/openvdb_ax/compiler/PointExecutable.cc
@@ -70,7 +70,11 @@ struct PointFunctionArguments
 {
     /// @brief  Base untyped handle struct for container storage
     ///
-    struct Handles { using UniquePtr = std::unique_ptr<Handles>; };
+    struct Handles
+    {
+        using UniquePtr = std::unique_ptr<Handles>;
+        virtual ~Handles() = default;
+    };
 
     /// @brief  A wrapper around a VDB Points Attribute Handle, allowing for
     ///         typed storage of a read or write handle. This is used for
@@ -78,13 +82,15 @@ struct PointFunctionArguments
     ///         generated point functions
     ///
     template <typename ValueT>
-    struct TypedHandle : public Handles
+    struct TypedHandle final : public Handles
     {
         using UniquePtr = std::unique_ptr<TypedHandle<ValueT>>;
         using HandleTraits = points::point_conversion_internal::ConversionTraits<ValueT>;
         using HandleT = typename HandleTraits::Handle;
 
         using LeafT = points::PointDataTree::LeafNodeType;
+
+        ~TypedHandle() override final = default;
 
         inline void*
         initReadHandle(const LeafT& leaf, const size_t pos) {

--- a/openvdb_ax/compiler/VolumeExecutable.cc
+++ b/openvdb_ax/compiler/VolumeExecutable.cc
@@ -67,12 +67,18 @@ using ReturnT = FunctionTraitsT::ReturnType;
 /// The arguments of the generated function
 struct VolumeFunctionArguments
 {
-    struct Accessors { using UniquePtr = std::unique_ptr<Accessors>; };
+    struct Accessors
+    {
+        using UniquePtr = std::unique_ptr<Accessors>;
+        virtual ~Accessors() = default;
+    };
 
     template <typename TreeT>
-    struct TypedAccessor : public Accessors
+    struct TypedAccessor final : public Accessors
     {
         using UniquePtr = std::unique_ptr<TypedAccessor<TreeT>>;
+
+        ~TypedAccessor() override final = default;
 
         inline void*
         init(TreeT& tree) {

--- a/openvdb_ax/test/integration/TestFunction.cc
+++ b/openvdb_ax/test/integration/TestFunction.cc
@@ -123,8 +123,8 @@ void
 TestFunction::testFunctionFit()
 {
     std::vector<double> values{23.0, -23.0, -25.0, -15.0, -15.0, -18.0, -24.0, 0.0, 10.0,
-        -5.0, 0.0, -1.0};
-    mHarness.addAttributes<double>(unittest_util::nameSequence("double_test", 12), values);
+        -5.0, 0.0, -1.0, 4.5, 4.5, 4.5, 4.5, 4.5};
+    mHarness.addAttributes<double>(unittest_util::nameSequence("double_test", 17), values);
 
     mHarness.executeCode("test/snippets/function/functionFit");
 

--- a/openvdb_ax/test/snippets/function/functionFit
+++ b/openvdb_ax/test/snippets/function/functionFit
@@ -34,3 +34,11 @@ double@double_test10 = fit(-3, 10, 0, -1, -5);
 
 double@double_test11 = fit(2,5,0,0,0);
 double@double_test12 = fit(10,0,0,0,-2);
+
+// test different argument type combinations
+
+double@double_test13 = fit(2.5, 2.0, 3.0f, 4.0f, 5.0f);
+double@double_test14 = fit(2.5f, 2.0f, 3.0f, 4.0f, 5.0f);
+double@double_test15 = fit(2.5, 2, 3.0f, 4.0f, 5.0);
+double@double_test16 = fit(2.5f, 2, 3.0f, 4.0f, 5.0f);
+double@double_test17 = fit(2.5, 2, 3.0, 4.0, 5.0);

--- a/openvdb_ax/version.h
+++ b/openvdb_ax/version.h
@@ -55,7 +55,7 @@
 // Library major, minor and patch version numbers
 #define OPENVDB_AX_LIBRARY_MAJOR_VERSION_NUMBER 0
 #define OPENVDB_AX_LIBRARY_MINOR_VERSION_NUMBER 0
-#define OPENVDB_AX_LIBRARY_PATCH_VERSION_NUMBER 3
+#define OPENVDB_AX_LIBRARY_PATCH_VERSION_NUMBER 4
 
 #define OPENVDB_AX_VERSION_NAME                                          \
     OPENVDB_PREPROC_CONCAT(v,                                            \


### PR DESCRIPTION
    Bug fixes:
    - Fixed a memory leak in Point and Volume Executable objects.
    - Fixed an issue with fit() which could use an incorrect precision for
      floating point arguments.
    - Compilation fixes for the Houdini AX SOP for Houdini 15.5 and earlier.

    Improvements:
    - Added a specialization for print for floats.
